### PR TITLE
3.2: Add partials module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -145,3 +145,6 @@
 [submodule "kohana-pagination"]
 	path = kohana-pagination
 	url = git://github.com/colinbm/kohana-pagination.git
+[submodule "partials"]
+	path = partials
+	url = git://github.com/gevans/kohana-partials.git


### PR DESCRIPTION
I've created a Kohana [partials module](https://github.com/gevans/kohana-partials) that adds support for Rails-style partial templates and would love to index it on kohana-modules.com.

Currently, there's support for versions 3.0, 3.1, and 3.2 of Kohana. I would send pull requests for the other two branches but I want to make sure it won't be too obnoxious. :)
