### PR TITLE
3.2: Added Gleez CMS module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -244,3 +244,6 @@
 [submodule "kohana-threads"]
 	path = kohana-threads
 	url = https://github.com/epicheals/kohana-threads.git
+[submodule "gleez"]
+	path = gleez
+	url  = https://github.com/gleez/cms.git


### PR DESCRIPTION
Added [Gleez CMS](https://github.com/gleez/cms) module for Kohana 3.2

See: 
- http://gleezcms.org
- http://demo.gleezcms.org
- http://forum.kohanaframework.org/discussion/11614/gleez-cms
